### PR TITLE
Make claim module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ extern crate pyo3;
 ))]
 mod bridge;
 
-pub mod claim;
+mod claim;
 pub mod client;
 pub mod crypto;
 mod duration;
@@ -41,4 +41,5 @@ pub use self::{
     error::ErrorKind,
     id::*,
     transaction::{PreCheckCode, TransactionId, TransactionStatus},
+    claim::Claim,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ extern crate pyo3;
 ))]
 mod bridge;
 
-mod claim;
+pub mod claim;
 pub mod client;
 pub mod crypto;
 mod duration;


### PR DESCRIPTION
Make claim module public so it can be used in the python sdk.