### PR TITLE
add copy trait to publickey

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -252,7 +252,7 @@ impl FromASN1 for PrivateKeyInfo {
 
 /// An ed25519 public key.
 #[repr(C)]
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Copy)]
 pub struct PublicKey(ed25519_dalek::PublicKey);
 
 impl PublicKey {


### PR DESCRIPTION
seems to be needed for some of the boxing in the c sdk.